### PR TITLE
fix: Corrected no-unused-import fix logic and its e2e test config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ _temp/
 *solhintReport*.*
 .env
 **/.DS_Store
-
+solhint*.tgz

--- a/e2e/08-autofix/no-unused-import/.solhint.json
+++ b/e2e/08-autofix/no-unused-import/.solhint.json
@@ -1,6 +1,6 @@
 {
   "rules": {
-    "no-unused-imports": "error",
+    "no-unused-import": "error",
     "compiler-version": "off"
   }
 }

--- a/e2e/08-autofix/no-unused-import/Foo1.sol
+++ b/e2e/08-autofix/no-unused-import/Foo1.sol
@@ -3,7 +3,8 @@ pragma solidity ^0.8.0;
 
 import { IERC20 } from '../token/interfaces/IERC20.sol';
 import { Bar, Civ, Zed as Nit } from '../Other.sol';
+import { Wyd, Abc as Mar } from '../Wyd.sol';
 
-contract Foo is Bar, Nit {
-    constructor() Bar() Nit(msg.sender) {}
+contract Foo is Bar, Nit, Wyd {
+    constructor() Bar() Nit(msg.sender) Wyd() {}
 }

--- a/e2e/08-autofix/no-unused-import/Foo1BeforeFix.sol
+++ b/e2e/08-autofix/no-unused-import/Foo1BeforeFix.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import { IERC20 } from '../token/interfaces/IERC20.sol';
 import { Bar, Civ, Zed as Nit } from '../Other.sol';
-import { Wyd, Mar } from '../Wyd.sol';
+import { Wyd, Abc as Mar } from '../Wyd.sol';
 
 contract Foo is Bar, Nit, Wyd {
     constructor() Bar() Nit(msg.sender) Wyd() {}

--- a/e2e/autofix-test.js
+++ b/e2e/autofix-test.js
@@ -695,7 +695,7 @@ describe('e2e', function () {
 
       it('should get the right report (11)', () => {
         const reportLines = stdout.split('\n')
-        const finalLine = '2 problems (2 errors, 0 warnings)'
+        const finalLine = '3 problems (3 errors, 0 warnings)'
         expect(reportLines[reportLines.length - 7]).to.contain(finalLine)
       })
     })

--- a/e2e/autofix-test.js
+++ b/e2e/autofix-test.js
@@ -682,7 +682,7 @@ describe('e2e', function () {
 
       it('should execute and compare Foo1 with template AFTER FIX and they should match (11)', () => {
         ;({ code, stdout } = shell.exec(
-            `${params.command} ${params.param1} -c ${currentConfig} ${currentFile} --fix --disc --noPrompt`
+          `${params.command} ${params.param1} -c ${currentConfig} ${currentFile} --fix --disc --noPrompt`
         ))
 
         result = compareTextFiles(currentFile, afterFixFile)
@@ -695,8 +695,7 @@ describe('e2e', function () {
 
       it('should get the right report (11)', () => {
         const reportLines = stdout.split('\n')
-        // TODO: fix `finalLine`
-        const finalLine = '9 problems (9 errors, 0 warnings)'
+        const finalLine = '2 problems (2 errors, 0 warnings)'
         expect(reportLines[reportLines.length - 7]).to.contain(finalLine)
       })
     })

--- a/lib/apply-fixes.js
+++ b/lib/apply-fixes.js
@@ -12,6 +12,12 @@ function applyFixes(fixes, inputSrc) {
 
   while (i < inputSrc.length) {
     if (fixIndex < fixes.length) {
+      // Skip fixes from the past
+      if (i > fixes[fixIndex].range[1]) {
+        fixIndex += 1
+        continue
+      }
+
       output += inputSrc.slice(i, fixes[fixIndex].range[0])
       output += fixes[fixIndex].text
       i = fixes[fixIndex].range[1] + 1

--- a/lib/rules/best-practices/no-unused-import.js
+++ b/lib/rules/best-practices/no-unused-import.js
@@ -87,6 +87,7 @@ class NoUnusedImportsChecker extends BaseChecker {
           used: false,
           group: this.groupCount,
           index,
+          aliasLength: it[1] ? it[1].name.length : 0,
         }
         this.importGroups[this.groupCount].count++
       })
@@ -104,6 +105,7 @@ class NoUnusedImportsChecker extends BaseChecker {
   }
 
   fixStatement(importedName) {
+    console.log('Node1: ', importedName.node)
     if (importedName.group !== undefined) {
       const group = this.importGroups[importedName.group]
 
@@ -113,10 +115,15 @@ class NoUnusedImportsChecker extends BaseChecker {
         return (fixer) => fixer.removeRange(group.range)
       }
 
-      // Delete identifier and comma separator and indentation if it's not the last one in the group
+      // Add comma separator and indentation to the range
       if (importedName.index < group.count - 1) {
         importedName.node.range[1] += 2
+      } else {
+        importedName.node.range[0] -= 2
       }
+
+      // Extend range with alias
+      importedName.node.range[1] += importedName.aliasLength ? importedName.aliasLength + 4 : 0
 
       // Remove the range of the identifier from the group range
       group.range[1] -= importedName.node.range[1] - importedName.node.range[0]

--- a/lib/rules/best-practices/no-unused-import.js
+++ b/lib/rules/best-practices/no-unused-import.js
@@ -125,6 +125,7 @@ class NoUnusedImportsChecker extends BaseChecker {
       importedName.node.range[1] += importedName.aliasLength ? importedName.aliasLength + 4 : 0
 
       // Remove the range of the identifier from the group range
+      group.count--
       group.range[1] -= importedName.node.range[1] - importedName.node.range[0]
     }
 

--- a/lib/rules/best-practices/no-unused-import.js
+++ b/lib/rules/best-practices/no-unused-import.js
@@ -80,7 +80,7 @@ class NoUnusedImportsChecker extends BaseChecker {
     if (node.unitAlias) {
       this.importedNames[node.unitAlias] = { node: node.unitAliasIdentifier, used: false }
     } else {
-      this.importGroups.push({ count: 0, range: node.range })
+      this.importGroups.push({ count: 0, updateCount: 0, range: node.range })
       node.symbolAliasesIdentifiers.forEach((it, index) => {
         this.importedNames[(it[1] || it[0]).name] = {
           node: it[0],
@@ -115,10 +115,10 @@ class NoUnusedImportsChecker extends BaseChecker {
       }
 
       // Add comma separator and indentation to the range
-      if (importedName.index < group.count - 1) {
-        importedName.node.range[1] += 2
-      } else {
+      if (importedName.index > group.updateCount) {
         importedName.node.range[0] -= 2
+      } else if (importedName.index < group.count + group.updateCount - 1) {
+        importedName.node.range[1] += 2
       }
 
       // Extend range with alias
@@ -126,7 +126,7 @@ class NoUnusedImportsChecker extends BaseChecker {
 
       // Remove the range of the identifier from the group range
       group.count--
-      group.range[1] -= importedName.node.range[1] - importedName.node.range[0]
+      group.updateCount++
     }
 
     return (fixer) => fixer.removeRange(importedName.node.range)

--- a/lib/rules/best-practices/no-unused-import.js
+++ b/lib/rules/best-practices/no-unused-import.js
@@ -105,7 +105,6 @@ class NoUnusedImportsChecker extends BaseChecker {
   }
 
   fixStatement(importedName) {
-    console.log('Node1: ', importedName.node)
     if (importedName.group !== undefined) {
       const group = this.importGroups[importedName.group]
 

--- a/lib/rules/best-practices/no-unused-import.js
+++ b/lib/rules/best-practices/no-unused-import.js
@@ -33,7 +33,7 @@ const meta = {
   isDefault: false,
   recommended: true,
   defaultSetup: 'warn',
-
+  fixable: true,
   schema: null,
 }
 
@@ -47,6 +47,9 @@ class NoUnusedImportsChecker extends BaseChecker {
     super(reporter, ruleId, meta)
     this.importedNames = {}
     this.tokens = tokens
+
+    this.groupCount = 0
+    this.importGroups = []
   }
 
   registerUsage(rawName) {
@@ -77,9 +80,17 @@ class NoUnusedImportsChecker extends BaseChecker {
     if (node.unitAlias) {
       this.importedNames[node.unitAlias] = { node: node.unitAliasIdentifier, used: false }
     } else {
-      node.symbolAliasesIdentifiers.forEach((it) => {
-        this.importedNames[(it[1] || it[0]).name] = { node: it[0], used: false }
+      this.importGroups.push({ count: 0, range: node.range })
+      node.symbolAliasesIdentifiers.forEach((it, index) => {
+        this.importedNames[(it[1] || it[0]).name] = {
+          node: it[0],
+          used: false,
+          group: this.groupCount,
+          index,
+        }
+        this.importGroups[this.groupCount].count++
       })
+      this.groupCount++
     }
   }
 
@@ -90,6 +101,28 @@ class NoUnusedImportsChecker extends BaseChecker {
   UsingForDeclaration(node) {
     this.registerUsage(node.libraryName)
     node.functions.forEach((it) => this.registerUsage(it))
+  }
+
+  fixStatement(importedName) {
+    if (importedName.group !== undefined) {
+      const group = this.importGroups[importedName.group]
+
+      // Delete whole import statement if it's the only one in the group
+      if (group.count === 1) {
+        group.range[1] += 1
+        return (fixer) => fixer.removeRange(group.range)
+      }
+
+      // Delete identifier and comma separator and indentation if it's not the last one in the group
+      if (importedName.index < group.count - 1) {
+        importedName.node.range[1] += 2
+      }
+
+      // Remove the range of the identifier from the group range
+      group.range[1] -= importedName.node.range[1] - importedName.node.range[0]
+    }
+
+    return (fixer) => fixer.removeRange(importedName.node.range)
   }
 
   'SourceUnit:exit'() {
@@ -105,7 +138,7 @@ class NoUnusedImportsChecker extends BaseChecker {
     })
     forIn(this.importedNames, (value, key) => {
       if (!value.used) {
-        this.error(value.node, `imported name ${key} is not used`)
+        this.error(value.node, `imported name ${key} is not used`, this.fixStatement(value))
       }
     })
   }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "lint": "eslint .",
     "generate-rulesets": "node scripts/generate-rulesets.js && prettier --write conf/rulesets",
     "docs": "node scripts/generate-rule-docs.js",
-    "prepublishOnly": "npm run lint && npm run test && npm run generate-rulesets"
+    "prepublishOnly": "npm run lint && npm run test && npm run generate-rulesets",
+    "e2e-test": "bash -c 'set -xeuo pipefail && npm pack && npm i -g solhint*tgz && (cd e2e && npm run test)'"
   },
   "bin": {
     "solhint": "solhint.js"

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "lint": "eslint .",
     "generate-rulesets": "node scripts/generate-rulesets.js && prettier --write conf/rulesets",
     "docs": "node scripts/generate-rule-docs.js",
-    "prepublishOnly": "npm run lint && npm run test && npm run generate-rulesets",
-    "e2e-test": "bash -c 'set -xeuo pipefail && npm pack && npm i -g solhint*tgz && (cd e2e && npm run test)'"
+    "prepublishOnly": "npm run lint && npm run test && npm run generate-rulesets"
   },
   "bin": {
     "solhint": "solhint.js"


### PR DESCRIPTION
Sorry, accidentally closed the previous PR.
List of changes:
- Fixed e2e test config for no-unused-imports.
- Added script to parent package that mimics e2e-test bash command.
- Implemented import deletion logic so e2e tests pass now.

Updates:
- Added import alias deletion
- Added unused alias import to test files